### PR TITLE
Define the SerialEvents trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,6 @@ authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
-[dependencies]
-vmm-sys-util = ">=0.6.1"
-
 [dev-dependencies]
 libc = ">=0.2.39"
+vmm-sys-util = ">=0.7.0"

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 97.7,
+  "coverage_score": 97.9,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
This PR proposes the `SerialEvents` (name subject to change) trait, which defines a series of callbacks which are invoked by the serial emulation logic when specific events occur (for example, when the driver reads or writes data). The `Serial` struct now has `V: SerialEvents` member field as well. Users can implement the trait for a custom type which (for example) increments metrics or logs messages in response to each event of interest. We also provide a no-op implementation that can be used by default.

The events currently identified by the methods in `SerialEvents` serve as an initial example. If the overall approach and implementation look good, we can proceed with setting up the first iteration of this list (which can subsequently grow).

