### PR TITLE
Send THR Empty interrupt even if write fails

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 97.9,
+  "coverage_score": 98.6,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Resolves: #23 

This change will allow the guest to receive the THR interrupt
even if the write failed on the host.

This will lose some bits, but for now is deemed a good enough
solution given the PIO interface still being discussed.