### PR TITLE
Serial: implementation of TX FIFO

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 98.9,
+  "coverage_score": 99.0,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Fixes #25 
To gain better general performance, a TX fifo for the Serial register is
introduced. With the THR fifo, a THR empty interrupt will be sent every
FIFO_SIZE bytes.

If the `out` descriptor is full, the content of the fifo is throwed
away.