### PR TITLE
Fix clippy warnings & fix copyright

### DIFF
--- a/src/i8042.rs
+++ b/src/i8042.rs
@@ -1,5 +1,5 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 //
 // Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/src/rtc_pl031.rs
+++ b/src/rtc_pl031.rs
@@ -733,7 +733,7 @@ mod tests {
         // Attempt to write to an address outside the expected range of
         // register memory.
         data = 123u32.to_le_bytes();
-        rtc.write(AMBA_ID_HIGH + 4, &mut data);
+        rtc.write(AMBA_ID_HIGH + 4, &data);
 
         // Invalid write should increment.  All others should not change.
         assert_eq!(rtc.events.invalid_read_count.count(), 0);
@@ -759,7 +759,7 @@ mod tests {
         // Attempt to write to an invalid register address close to the load
         // register's address.
         data = 123u32.to_le_bytes();
-        rtc.write(RTCLR + 1, &mut data);
+        rtc.write(RTCLR + 1, &data);
 
         // Invalid write should increment again.  All others should not change.
         assert_eq!(rtc.events.invalid_read_count.count(), 0);

--- a/src/rtc_pl031.rs
+++ b/src/rtc_pl031.rs
@@ -1,5 +1,5 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 //! Provides emulation for a minimal ARM PL031 Real Time Clock.
 //!


### PR DESCRIPTION
- There is no need for `write` to receive a mutable reference
- The copyright for a few files was only specifying the Apache 2.0 license; updated it to Apache OR BSD 3-Clause; Thanks @alexandruag for reporting this