### PR TITLE
Fix RTC implementation for the Data Register (DR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ this support only for the
 [Linux serial console](https://en.wikipedia.org/wiki/Linux_console), a minimal
 [i8042 PS/2 Controller](https://wiki.osdev.org/%228042%22_PS/2_Controller) and
 an
-[ARM PL031 Real Time Clock](https://static.docs.arm.com/ddi0224/c/real_time_clock_pl031_r1p3_technical_reference_manual_DDI0224C.pdf).
+[ARM PL031 Real Time Clock](https://developer.arm.com/documentation/ddi0224/c/Programmers-model).
 
 ## Serial Console
 

--- a/src/rtc_pl031.rs
+++ b/src/rtc_pl031.rs
@@ -11,11 +11,9 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-// As you can see in
-//  https://static.docs.arm.com/ddi0224/c/real_time_clock_pl031_r1p3_technical_reference_manual_DDI0224C.pdf
-//  at section 3.2 Summary of RTC registers, the total size occupied by this
-//  device is 0x000 -> 0xFFC + 4 = 0x1000 bytes.
-
+// The following defines are mapping to the specification:
+// https://developer.arm.com/documentation/ddi0224/c/Programmers-model/Summary-of-RTC-registers
+//
 // From 0x0 to 0x1C we have following registers:
 const RTCDR: u16 = 0x000; // Data Register (RO).
 const RTCMR: u16 = 0x004; // Match Register.


### PR DESCRIPTION
The DR register needs to return the current time + any adjustments made by the driver. With the previous implementation, the time was in the 1970.