### PR TITLE
removed local dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gitsubmodule
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10


### PR DESCRIPTION
We are going to use the per org dependabot configuration instead so that
we can configure the updates seamlessly on all repositories at the same
time.

The configuration can be found here:
https://github.com/rust-vmm/.github