### PR TITLE
i8042: add `I8042Device::reset_evt()` method

### DIFF
--- a/vm-superio/CHANGELOG.md
+++ b/vm-superio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# Upcoming version
+
+## Changed
+
+- Added a `reset_evt` to the `I8042Device` type to retrieve the underlying
+  reset event object.
+
 # v0.7.0
 
 ## Changed

--- a/vm-superio/src/i8042.rs
+++ b/vm-superio/src/i8042.rs
@@ -86,6 +86,11 @@ impl<T: Trigger> I8042Device<T> {
         I8042Device { reset_evt }
     }
 
+    /// Provides a reference to the reset event object.
+    pub fn reset_evt(&self) -> &T {
+        &self.reset_evt
+    }
+
     /// Handles a read request from the driver at `_offset` offset from the
     /// base I/O address.
     ///


### PR DESCRIPTION
### Summary of the PR

Make the `I8042Device` implementation more symmetric with other devices by allowing the user to get a reference to the underlying trigger descriptor.

The `Serial` device has a similar method called `interrupt_evt()`

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
