### PR TITLE
serial: implement receive FIFO flush via FCR

### DIFF
--- a/vm-superio/CHANGELOG.md
+++ b/vm-superio/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Upcoming Release
 
+### Changed
+
+- Implemented receive FIFO flushing via the FCR register for the `Serial`
+  device ([#83](https://github.com/rust-vmm/vm-superio/issues/83)).
+
 ## v0.8.1
 
 ### Changed


### PR DESCRIPTION
### Summary of the PR

The FIFO Control Register (FCR) controls the behavior of the receive and transmit FIFO buffers of the device. The current implementation does not emulate this register, as FIFO buffers are always enabled. However, there are two bits in this register that control flushing of said FIFOS. The transmission FIFO is already flushed by the current implementation on every write, but the receive FIFO is not. This is problematic, as some driver implementations (e.g. FreeBSD's) rely on being able to clear this buffer via the corresponding bit.

Implement the correct behavior when a driver sets this bit by clearing `in_buffer`. Since there is no more data in the receive FIFO, the data-ready bit in the Line Status Register (LSR) must be cleared as well, in case it was set.

Add a test for this new feature as well.

Fixes #83 

### Requirements

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- `N/A` Any newly added `unsafe` code is properly documented.
