### PR TITLE
Release vm-superio v0.8.0 and vm-superio-ser v0.4.0

### DIFF
--- a/vm-superio-ser/CHANGELOG.md
+++ b/vm-superio-ser/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
-# v0.3.0
+# v0.4.0
 
 ## Changed
 
 - Updated vmm-sys-util dependency to 0.12.1
 - Updated versionize dependency to 0.2.0
+
+# v0.3.0
+
+## Changed
+
+- Updated vmm-sys-util dependency to 0.11.0
 - Switched to specifying dependencies using caret requirements
   instead of comparision requirements
 

--- a/vm-superio-ser/Cargo.toml
+++ b/vm-superio-ser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-superio-ser"
-version = "0.3.0"
+version = "0.4.0"
 description = "Serialization for legacy device states"
 keywords = ["superio", "serialization", "versioning"]
 repository = "https://github.com/rust-vmm/vm-superio"
@@ -19,7 +19,7 @@ versionize_derive = "0.1.3"
 # We are using a fixed version of `vm-superio` so that the current version
 # of `vm-superio-ser` won't take a newer version of vm-superio, with which
 # it may not be compatible.
-vm-superio = { version = "=0.7.0", path = "../vm-superio" }
+vm-superio = { version = "=0.8.0", path = "../vm-superio" }
 
 [dev-dependencies]
 libc = "0.2.39"

--- a/vm-superio/CHANGELOG.md
+++ b/vm-superio/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# Upcoming version
+# v0.8.0
 
 ## Changed
 

--- a/vm-superio/Cargo.toml
+++ b/vm-superio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-superio"
-version = "0.7.0"
+version = "0.8.0"
 description = "Emulation for legacy devices"
 keywords = ["superio", "emulation"]
 repository = "https://github.com/rust-vmm/vm-superio"


### PR DESCRIPTION
### Summary of the PR

Both libraries were not released for more then a year and it leads to dependency conflicts
when used together with other more up-to-date `rust-vmm` crates.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
