### PR TITLE
vm-superio-ser: remove versionize support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ containing the following crates:
 - `vm-superio-ser` - which mirrors the state structure from `vm-superio` and
    adds the required version constraints on it, and derives/implements the
   required (de)serialization traits (i.e. `serde`'s `Serialize` and
-  `Deserialize`; `Versionize`).
+  `Deserialize`).
 
 ## Serial Console
 
@@ -125,7 +125,7 @@ This support is offered for the `Rtc` and the `Serial` devices by the following
 abstractions:
 - `<Device>State` -> which keeps the hardware state of the `<Device>`;
 - `<Device>StateSer` -> which can be used by customers who need a
-  `<Device>State` that is also `(De)Serialize` and/or `Versionize`. If the
+  `<Device>State` that is also `(De)Serialize`. If the
   customers want a different state than the upstream one, then they can
   implement `From` (or similar mechanisms) in their products to convert the
   upstream state to the desired product state.

--- a/vm-superio-ser/CHANGELOG.md
+++ b/vm-superio-ser/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming Release
 
+### Removed
+
+- Remove versionize support
+
 ## v0.4.1
 
 ### Changed

--- a/vm-superio-ser/Cargo.toml
+++ b/vm-superio-ser/Cargo.toml
@@ -11,8 +11,6 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.27", features = ["derive"] }
-versionize = "0.2.0"
-versionize_derive = "0.1.3"
 # Combining both `version` and `path` so that it is possible to publish
 # the crate on crates.io. More details here:
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations.

--- a/vm-superio-ser/src/lib.rs
+++ b/vm-superio-ser/src/lib.rs
@@ -5,7 +5,7 @@
 //! Adds to the state objects from `vm-superio` serialization capabilities.
 //!
 //! Provides wrappers over the state objects from `vm-superio` crate which
-//! implement the `Serialize`, `Deserialize` and `Versionize` traits as well.
+//! implement the `serde::Serialize/Deserialize` traits as well.
 
 #![deny(missing_docs)]
 

--- a/vm-superio-ser/src/rtc_pl031.rs
+++ b/vm-superio-ser/src/rtc_pl031.rs
@@ -6,15 +6,13 @@
 //!
 //! This module defines the `RtcStateSer` abstraction which mirrors the
 //! `RtcState` from the base crate, and adds on top of it derives for
-//! the `Serialize`, `Deserialize` and `Versionize` traits.
+//! the `serde::Serialize/Deserialize` traits.
 
 use serde::{Deserialize, Serialize};
-use versionize::{VersionMap, Versionize, VersionizeResult};
-use versionize_derive::Versionize;
 use vm_superio::RtcState;
 
 /// Wrapper over an `RtcState` that has serialization capabilities.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, Versionize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct RtcStateSer {
     /// The load register.
     pub lr: u32,

--- a/vm-superio-ser/src/serial.rs
+++ b/vm-superio-ser/src/serial.rs
@@ -6,15 +6,13 @@
 //!
 //! This module defines the `SerialStateSer` abstraction which mirrors the
 //! `SerialState` from the base crate, and adds on top of it derives for
-//! the `Serialize`, `Deserialize` and `Versionize` traits.
+//! the `serde::Serialize/Deserialize` traits.
 
 use serde::{Deserialize, Serialize};
-use versionize::{VersionMap, Versionize, VersionizeResult};
-use versionize_derive::Versionize;
 use vm_superio::SerialState;
 
 /// Wrapper over an `SerialState` that has serialization capabilities.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, Versionize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct SerialStateSer {
     /// Divisor Latch Low Byte
     pub baud_divisor_low: u8,
@@ -164,19 +162,5 @@ mod tests {
         let state_der = bincode::deserialize(&state_ser).unwrap();
 
         assert_eq!(state, state_der);
-    }
-
-    #[test]
-    fn test_versionize() {
-        let map = VersionMap::new();
-        let state = SerialStateSer::default();
-        let mut v1_state = Vec::new();
-
-        Versionize::serialize(&state, &mut v1_state, &map, 1).unwrap();
-
-        let from_v1: SerialStateSer =
-            Versionize::deserialize(&mut v1_state.as_slice(), &map, 1).unwrap();
-
-        assert_eq!(from_v1, state);
     }
 }


### PR DESCRIPTION
versionize crate is deprecated and it depends on the deprecated bincode crate.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
